### PR TITLE
Remove return instruction outside of function

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,10 @@ if (typeof window === 'object') {
   // Node.js or Web worker
   try {
     var crypto = require('cry' + 'pto');
+
+    Rand.prototype._rand = function _rand(n) {
+      return crypto.randomBytes(n);
+    };
   } catch (e) {
     // Emulate crypto API using randy
     Rand.prototype._rand = function _rand(n) {
@@ -49,9 +53,5 @@ if (typeof window === 'object') {
         res[i] = this.rand.getByte();
       return res;
     };
-    return;
   }
-  Rand.prototype._rand = function _rand(n) {
-    return crypto.randomBytes(n);
-  };
 }


### PR DESCRIPTION
This is breaking Uglify32 compilation of various dependent modules, for example:

```
[...] elliptic/node_modules/brorand/index.js { message: '\'return\' outside of function',
  line: 52,
  col: 10,
  pos: 1216,
  stack: 'Error\n    at new JS_Parse_Error [...]
```
