### PR TITLE
Move browser code to separate module

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,28 @@
+var util = require("./util");
+
+module.exports = util.rand;
+var Rand = module.exports.Rand = util.Rand;
+
+if (window.crypto && window.crypto.getRandomValues) {
+  // Modern browsers
+  Rand.prototype._rand = function _rand(n) {
+    var arr = new Uint8Array(n);
+    window.crypto.getRandomValues(arr);
+    return arr;
+  };
+} else if (window.msCrypto && window.msCrypto.getRandomValues) {
+  // IE
+  Rand.prototype._rand = function _rand(n) {
+    var arr = new Uint8Array(n);
+    window.msCrypto.getRandomValues(arr);
+    return arr;
+  };
+} else {
+  // Emulate crypto API using randy
+  Rand.prototype._rand = function _rand(n) {
+    var res = new Uint8Array(n);
+    for (var i = 0; i < res.length; i++)
+      res[i] = this.rand.getByte();
+    return res;
+  };
+}

--- a/index.js
+++ b/index.js
@@ -1,57 +1,9 @@
-var r;
+var crypto = require("crypto");
+var util = require("./util");
 
-module.exports = function rand(len) {
-  if (!r)
-    r = new Rand(null);
+module.exports = util.rand;
+var Rand = module.exports.Rand = util.Rand;
 
-  return r.generate(len);
+Rand.prototype._rand = function _rand(n) {
+  return crypto.randomBytes(n);
 };
-
-function Rand(rand) {
-  this.rand = rand;
-}
-module.exports.Rand = Rand;
-
-Rand.prototype.generate = function generate(len) {
-  return this._rand(len);
-};
-
-if (typeof window === 'object') {
-  if (window.crypto && window.crypto.getRandomValues) {
-    // Modern browsers
-    Rand.prototype._rand = function _rand(n) {
-      var arr = new Uint8Array(n);
-      window.crypto.getRandomValues(arr);
-      return arr;
-    };
-  } else if (window.msCrypto && window.msCrypto.getRandomValues) {
-    // IE
-    Rand.prototype._rand = function _rand(n) {
-      var arr = new Uint8Array(n);
-      window.msCrypto.getRandomValues(arr);
-      return arr;
-    };
-  } else {
-    // Old junk
-    Rand.prototype._rand = function() {
-      throw new Error('Not implemented yet');
-    };
-  }
-} else {
-  // Node.js or Web worker
-  try {
-    var crypto = require('cry' + 'pto');
-
-    Rand.prototype._rand = function _rand(n) {
-      return crypto.randomBytes(n);
-    };
-  } catch (e) {
-    // Emulate crypto API using randy
-    Rand.prototype._rand = function _rand(n) {
-      var res = new Uint8Array(n);
-      for (var i = 0; i < res.length; i++)
-        res[i] = this.rand.getByte();
-      return res;
-    };
-  }
-}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.5",
   "description": "Random number generator for browsers and node.js",
   "main": "index.js",
+  "browser": "browser.js",
   "scripts": {
     "test": "mocha --reporter=spec test/**/*-test.js"
   },

--- a/util.js
+++ b/util.js
@@ -1,0 +1,18 @@
+var r;
+
+exports.rand = function rand(len) {
+  if (!r)
+    r = new Rand(null);
+
+  return r.generate(len);
+};
+
+function Rand(rand) {
+  this.rand = rand;
+}
+
+Rand.prototype.generate = function generate(len) {
+  return this._rand(len);
+};
+
+exports.Rand = Rand;


### PR DESCRIPTION
Hi!

While [this issue](https://github.com/indutny/elliptic/pull/26) is not merged yet I moved out browser-related code to the separate module. The problem with the current code is that [webpack](https://github.com/webpack/webpack) tries to be smart and expands simple expressions in `require`. So `require('cry' + 'pto')` got expanded to the `require('crypto')` and entire `crypto-browserify` package got included to the build which is rather big.

You use this library in [elliptic](https://github.com/indutny/elliptic) so it's rather unpleasant to have such big dependency to the elliptic module.

Thanks.