### PR TITLE
Hide the `require('crypto')` from webpack

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,8 @@ if (typeof window === 'object') {
 } else {
   // Node.js or Web worker
   try {
-    var crypto = require('cry' + 'pto');
+    var hiddenRequire = require;
+    var crypto = hiddenRequire('crypto');
 
     Rand.prototype._rand = function _rand(n) {
       return crypto.randomBytes(n);


### PR DESCRIPTION
Webpack is able to see through the string manipulation.
We need to obscure the `require` function itself.

There is another pull request, #3, which does the same thing in a better way, but that has been sitting un-touched for over a year. This is a less-invasive way of doing the same basic thing.