### PR TITLE
fallback to node.js crypto for old junk

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,8 +35,7 @@ if (typeof window === 'object') {
     // Old junk
     Rand.prototype._rand = function() {
       try {
-            var crypto = require('crypto');
-            return crypto.randomBytes(n);
+            return require('randombytes')(n);
         } catch (e) {
             throw new Error('Not implemented yet');
         }

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ if (typeof window === 'object') {
     };
   } else {
     // Old junk
-    Rand.prototype._rand = function() {
+    Rand.prototype._rand = function(n) {
       try {
             return require('randombytes')(n);
         } catch (e) {

--- a/index.js
+++ b/index.js
@@ -34,7 +34,12 @@ if (typeof window === 'object') {
   } else {
     // Old junk
     Rand.prototype._rand = function() {
-      throw new Error('Not implemented yet');
+      try {
+            var crypto = require('crypto');
+            return crypto.randomBytes(n);
+        } catch (e) {
+            throw new Error('Not implemented yet');
+        }
     };
   }
 } else {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "url": "https://github.com/indutny/brorand/issues"
   },
   "homepage": "https://github.com/indutny/brorand",
+  "dependencies": {
+    "randombytes": "^2.0.3"
+  },
   "devDependencies": {
     "mocha": "^2.0.1"
   },


### PR DESCRIPTION
Hi @indutny 
For react based app testing, `window` is available but no window.crypto library. 
Falling back to node.js crypto workaround seems to solve the issue.