### PR TITLE
Allow for asynchronous resolution of crypto library

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,14 +52,21 @@ if (typeof self === 'object') {
   }
 } else {
   // Node.js or Web worker with no crypto support
-  try {
-    var crypto = require('crypto');
+  var cachedCrypto;
+  function getCrypto() {
+    if (!cachedCrypto) {
+      cachedCrypto = require('crypto');
+    }
+
+    return cachedCrypto;
+  }
+
+
+  Rand.prototype._rand = function _rand(n) {
+    var crypto = getCrypto();
     if (typeof crypto.randomBytes !== 'function')
       throw new Error('Not supported');
 
-    Rand.prototype._rand = function _rand(n) {
-      return crypto.randomBytes(n);
-    };
-  } catch (e) {
-  }
+    return crypto.randomBytes(n);
+  };
 }


### PR DESCRIPTION
In React Native, the standard node libraries are not available, so the `crypto` library needs to be aliased to point to [react-native-crypto](https://github.com/tradle/react-native-crypto).

However, in order to re-implement crypto, the Diffie-Hellman methods are pulled in from [crypto-browserify/diffie-hellman](https://github.com/crypto-browserify/diffie-hellman), which, in turn depends on this project.

This project itself requires `crypto`, so we have a nice dependency loop which causes the whole thing to crash.

If, on the other hand, we allow for `require('crypto')` to happen at the time of the _call_ of `Rand.prototype._rand`, all of the files can get read without introducing a loop and the dependency tree can get sorted out properly.