### PR TITLE
Web circular dependency workaround

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ if (typeof self === 'object') {
 } else {
   // Node.js or Web worker with no crypto support
   try {
-    var crypto = require('crypto');
+    var crypto = eval('require')('crypto');
     if (typeof crypto.randomBytes !== 'function')
       throw new Error('Not supported');
 


### PR DESCRIPTION
Quick fix for a circular dependency when using crypto-browserify with web module bundlers (in this case Angular CLI / webpack):

`WARNING in Circular dependency detected: src/js/externals/crypto.ts -> node_modules/crypto-browserify/index.js -> node_modules/diffie-hellman/browser.js -> node_modules/diffie-hellman/lib/generatePrime.js -> node_modules/miller-rabin/lib/mr.js -> node_modules/brorand/index.js -> src/js/externals/crypto.ts`

(Using `eval` this way feels a bit hackish, but I'm not aware of anything like Content Security Policy that would break it in a Node.js context, and I've been using this exact technique in all of @cyph's crypto libraries for a while now with no known issues.)